### PR TITLE
Make extra-deps optional

### DIFF
--- a/__tests__/fixtures/stackNoExtraDeps.yaml
+++ b/__tests__/fixtures/stackNoExtraDeps.yaml
@@ -1,0 +1,4 @@
+resolver: lts-21.16
+
+packages:
+  - .

--- a/__tests__/yaml.test.ts
+++ b/__tests__/yaml.test.ts
@@ -41,6 +41,14 @@ describe('yaml.ts', () => {
     expect(extraDeps[0].name).toBe('polysemy-zoo')
   })
 
+  it('should get an empty list of extra deps package info if no extra-deps is defined', async () => {
+    const { doc } = await getStackYaml(`${__dirname}/fixtures/stackNoExtraDeps.yaml`)
+
+    const extraDeps = await getExtraDeps(doc)
+
+    expect(extraDeps).toHaveLength(0)
+  })
+
   it('should set extra deps', async () => {
     const { doc } = await getStackYaml(`${__dirname}/fixtures/stack.yaml`)
 

--- a/__tests__/yaml.test.ts
+++ b/__tests__/yaml.test.ts
@@ -42,7 +42,9 @@ describe('yaml.ts', () => {
   })
 
   it('should get an empty list of extra deps package info if no extra-deps is defined', async () => {
-    const { doc } = await getStackYaml(`${__dirname}/fixtures/stackNoExtraDeps.yaml`)
+    const { doc } = await getStackYaml(
+      `${__dirname}/fixtures/stackNoExtraDeps.yaml`
+    )
 
     const extraDeps = await getExtraDeps(doc)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -4252,8 +4252,8 @@ function separateString(inputString) {
 }
 const getExtraDeps = async (doc) => {
     const extraDeps = doc.get('extra-deps');
-    const json = extraDeps.toJSON();
-    return json.map(separateString);
+    const json = extraDeps?.toJSON();
+    return (json || []).map(separateString);
 };
 exports.getExtraDeps = getExtraDeps;
 const setExtraDeps = async (doc, extraDeps) => {

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -36,9 +36,9 @@ function separateString(inputString: string): Package {
 export const getExtraDeps = async (doc: Document): Promise<Package[]> => {
   const extraDeps = doc.get('extra-deps') as YAMLSeq
 
-  const json = extraDeps.toJSON() as string[]
+  const json = extraDeps?.toJSON() as string[]
 
-  return json.map(separateString)
+  return (json || []).map(separateString)
 }
 
 export const setExtraDeps = async (


### PR DESCRIPTION
Hello and thank you for `dep-haskell-stack`! I'm enjoying this GitHub Action a lot!

I've found out that this action will throw an error (like [this one](https://github.com/Vincibean/Vincibean.github.io/actions/runs/8823180186/job/24223061153)) if `stack.yaml` doesn't have any `extra-deps` defined.  [From what I gather](https://docs.haskellstack.org/en/stable/yaml_configuration/#extra-deps), this field is optional (and defaults to an empty list), so I thought I would try to recreate that behaviour in this PR.

Note that, as a workaround, explicitly defining an empty `extra deps` will work; this PR only aims at covering the case when `extra-deps` is not explicitly defined.

I hope you will find this PR useful; don't hesitate to let me know if there's something that you'd like changes, or if it doesn't align with the vision you have with `dep-haskell-stack`.